### PR TITLE
feat(backend): implement tweet policy and updated schema

### DIFF
--- a/app/Http/Requests/TweetRequest.php
+++ b/app/Http/Requests/TweetRequest.php
@@ -22,10 +22,10 @@ class TweetRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => 'string|max:255|required|min:5',
-            'status' => 'in:draft,published',
-            'content' => 'string|max:1000|required|min:5',
-            'image' => 'nullable|image|max:2048',
+            'content' => 'nullable|string|max:280|required_without:images',
+            'images' => 'nullable|array|max:4|required_without:content',
+            'images.*' => 'image|mimes:jpeg,png,jpg,gif|max:2048',
+            'status' => 'nullable|in:draft,published'
         ];
     }
 }

--- a/app/Models/Tweet.php
+++ b/app/Models/Tweet.php
@@ -9,12 +9,15 @@ class Tweet extends Model
 {
     use HasFactory;
     protected $fillable = [
-        'title',
         'content',
         'user_id',
         'status',
         'slug',
-        'image',
+        'images',
+    ];
+
+    protected $casts = [
+        'images' => 'array',
     ];
 
     public function user()

--- a/app/Policies/TweetPolicy.php
+++ b/app/Policies/TweetPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tweet;
+use App\Models\User;
+
+class TweetPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Tweet $tweet): bool
+    {
+        return $tweet->status === 'published' ||
+           ($user && $user->id === $tweet->user_id);
+
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Tweet $tweet): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Tweet $tweet): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Tweet $tweet): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Tweet $tweet): bool
+    {
+        return false;
+    }
+}

--- a/database/factories/TweetFactory.php
+++ b/database/factories/TweetFactory.php
@@ -17,12 +17,10 @@ class TweetFactory extends Factory
      */
     public function definition(): array
     {
-        $title = $this->faker->sentence(rand(3, 6));
-        $slug = Str::slug($title. '-' . time());
+        $slug = Str::random(32);
 
         return [
             'user_id' => 1,
-            'title' => $title,
             'content' => $this->faker->paragraphs(3, true),
             'slug' => $slug,
             'status' => $this->faker->randomElement(['draft', 'published']),

--- a/database/migrations/2025_06_13_180157_create_tweets_table.php
+++ b/database/migrations/2025_06_13_180157_create_tweets_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
@@ -13,13 +14,19 @@ return new class extends Migration {
         Schema::create('tweets', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->string('title');
-            $table->text('content');
-            $table->string('image')->nullable();
+            $table->text('content')->nullable();
+            $table->json('images')->nullable();
             $table->string('slug')->unique();
             $table->enum('status', ['draft', 'published'])->default('draft');
             $table->timestamps();
         });
+
+        // Add check constraint using raw SQL
+        DB::statement('
+            ALTER TABLE tweets 
+            ADD CONSTRAINT chk_content_or_images 
+            CHECK (content IS NOT NULL OR images IS NOT NULL)
+        ');
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\TweetController;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
@@ -14,10 +15,10 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::controller(TweetController::class)->prefix('tweets')->group(function () {
         Route::get('/', 'index')->name('tweets.index');
         Route::post('/', 'store')->name('tweets.store');
-        Route::get('/{tweet}', 'show')->name('tweets.show');
+        Route::get('/{slug}', 'show')->name('tweets.show');
+
     });
 });
-
 
 Route::group(['middleware' => ['guest']], function () {
     Route::post('/register', [AuthController::class, 'register'])->name('register');


### PR DESCRIPTION
- Added draft visibility policy (only visible to creators)
- Updated tweet schema to remove title field
- Implemented content/images validation (either required)
- Added multiple image upload support
- Created policy middleware for tweet access control
- Updated API responses with new tweet format